### PR TITLE
Temporary look for changes from last workflow run

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Merge upstream
         run: |
 
-          export since="1 day ago"
+          export since="2024-08-24"
 
           # Checkout the repository
           echo "*** Configuring the local git ***"


### PR DESCRIPTION
The workflow stopped to run because of repo inactivity by github, so there is a hole between last run (2024-08-24) and now.

Changing the hardcoded "since" in the image daily deploy workflow in order to look from that date.

After merging this:
- [ ] run the workflow running 
- [ ] make another PR to revert this commit to continue to check daily once the workflow is running successfully

Likely, this PR should be repeated once github will stop the workflow in 1 month because of inactivity...